### PR TITLE
Add special permission based on user type + new CustomUser API methods

### DIFF
--- a/revm/app_account/admin.py
+++ b/revm/app_account/admin.py
@@ -24,13 +24,17 @@ DjangoUserAdmin.add_fieldsets = (
 
 @admin.register(models.CustomUser)
 class AdminCustomUser(DjangoUserAdmin):
-    list_display = ("id", "first_name", "last_name", "email", "phone_number", "type")
+    list_display = ("id", "first_name", "last_name", "email", "phone_number", "type", "user_type")
     list_display_links = ["id", "first_name", "last_name", "email"]
     search_fields = ("email", "first_name", "last_name")
     list_filter = ["is_validated"]
-
     ordering = ("first_name",)
     change_form_template = "admin/user_admin.html"
+
+    def get_readonly_fields(self, request, obj=None):
+        if request.user.is_dsu_manager_user():
+            return ["is_superuser", "user_permissions", "groups"]
+        return self.readonly_fields
 
     def get_fieldsets(self, request, obj=None):
         if obj:
@@ -46,13 +50,10 @@ class AdminCustomUser(DjangoUserAdmin):
                 ),
                 (_("Personal info"), {"fields": ("first_name", "last_name", "password")}),
                 (_("Profile data"), {"fields": ("phone_number", "address")}),
-                # Restricting Set Superuser to superuser
                 (
                     _("Permissions"),
                     {
                         "fields": ("is_active", "is_staff", "is_superuser", "user_permissions", "groups")
-                        if request.user.is_superuser
-                        else ("is_active", "is_staff")
                     },
                 ),
                 (
@@ -64,7 +65,7 @@ class AdminCustomUser(DjangoUserAdmin):
             return self.add_fieldsets
 
     def has_delete_permission(self, request, obj=None):
-        if not (request.user.is_superuser or request.user.groups.filter(name=models.DSU_MANAGER_GROUP).exists()):
+        if not (request.user.is_superuser or request.user.is_dsu_manager_user()):
             return False
         if obj and hasattr(obj, "email"):
             if obj.email == settings.SUPER_ADMIN_EMAIL:
@@ -72,7 +73,7 @@ class AdminCustomUser(DjangoUserAdmin):
         return True
 
     def has_change_permission(self, request, obj=None):
-        if not (request.user.is_superuser or request.user.groups.filter(name=models.DSU_MANAGER_GROUP).exists()):
+        if not (request.user.is_superuser or request.user.is_dsu_manager_user()):
             return False
         if obj and hasattr(obj, "email"):
             if obj.email == settings.SUPER_ADMIN_EMAIL:
@@ -81,7 +82,7 @@ class AdminCustomUser(DjangoUserAdmin):
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
-        if request.user.is_superuser or request.user.groups.filter(name=models.DSU_MANAGER_GROUP).exists():
+        if request.user.is_superuser or request.user.is_dsu_manager_user():
             return qs
         return qs.filter(pk=request.user.id)
 

--- a/revm/app_account/management/commands/seed_groups.py
+++ b/revm/app_account/management/commands/seed_groups.py
@@ -5,7 +5,6 @@ from app_account.models import USERS_GROUP, DSU_GROUP, DSU_MANAGER_GROUP
 
 
 # NOTE restricted for current user via admin `get_queryset` if current user in USER_GROUP, no restrictions for DSU_GROUP
-# TODO #78 Special permissions
 user_and_dsu_permissions = [
     "view_customuser",
     "view_itemoffer",

--- a/revm/app_account/models.py
+++ b/revm/app_account/models.py
@@ -10,18 +10,35 @@ DSU_MANAGER_GROUP = "DSU Manager"
 class CustomUser(AbstractUser):
     REQUIRED_FIELDS = []
     USERNAME_FIELD = "email"
-    TYPES_CHOICES = ((1, _("Individual")), (2, _("Corporate")), (3, _("Non-Profit")), (4, _("Government")))
+    TYPES_CHOICES = (
+        (1, _("Individual")),
+        (2, _("Corporate")),
+        (3, _("Non-Profit")),
+        (4, _("Government")),
+    )
 
-    business_name = models.CharField(_("bussiness name"), max_length=255, null=True, blank=True)
-    identification_no = models.CharField(_("identification number"), max_length=25, null=True, blank=True)
+    business_name = models.CharField(
+        _("bussiness name"), max_length=255, null=True, blank=True
+    )
+    identification_no = models.CharField(
+        _("identification number"), max_length=25, null=True, blank=True
+    )
 
     email = models.EmailField(_("email address"), unique=True)
 
     type = models.SmallIntegerField(_("type"), choices=TYPES_CHOICES, default=1)
-    phone_number = models.CharField(_("phone number"), max_length=13, null=True, blank=True)
+    phone_number = models.CharField(
+        _("phone number"), max_length=13, null=True, blank=True
+    )
     address = models.CharField(_("address"), max_length=255, blank=True, null=True)
     details = models.JSONField(_("details"), null=True, blank=True)
-    description = models.CharField(_("general user description"), default="", blank=True, null=False, max_length=500)
+    description = models.CharField(
+        _("general user description"),
+        default="",
+        blank=True,
+        null=False,
+        max_length=500,
+    )
 
     is_validated = models.BooleanField(default=False)
 
@@ -41,3 +58,36 @@ class CustomUser(AbstractUser):
 
     def get_full_name(self):
         return f"{self.first_name} {self.last_name}"
+
+    def is_regular_user(self):
+        return self.groups.filter(name=USERS_GROUP).exists() and not (
+            self.is_dsu_user() or self.is_dsu_manager_user() or self.is_superuser
+        )
+
+    def is_dsu_user(self):
+        return self.groups.filter(name=DSU_GROUP).exists() and not (
+            self.is_dsu_manager_user() or self.is_superuser
+        )
+
+    def is_dsu_manager_user(self):
+        return (
+            self.groups.filter(name=DSU_MANAGER_GROUP).exists()
+            and not self.is_superuser
+        )
+
+    def user_type(self):
+        if self.is_superuser:
+            return _("Admin")
+        
+        if self.is_dsu_manager_user():
+            return _(DSU_MANAGER_GROUP)
+        
+        if self.is_dsu_user():
+            return _(DSU_GROUP)
+
+        if self.is_regular_user():
+            return _(USERS_GROUP)
+        
+        return _("NO GROUP ASSIGNED")
+
+    user_type.short_description = _("User Type")

--- a/revm/app_item/admin.py
+++ b/revm/app_item/admin.py
@@ -4,12 +4,12 @@ from django.forms import Textarea
 from django.utils.translation import gettext_lazy as _
 
 from app_item import models
-from app_account.models import USERS_GROUP, DSU_GROUP
+from app_account.models import  CustomUser, DSU_GROUP
 from revm_site.admin import CommonRequestInline, CommonOfferInline
 
 
 def deactivate_offers(modeladmin, request, queryset):
-    if request.user.is_superuser or request.user.groups.filter(name=DSU_GROUP).exists():
+    if request.user.is_superuser or request.user.is_dsu_user():
         queryset.update(status="D")
 
     queryset.filter(donor=request.user).update(status="D")
@@ -20,12 +20,46 @@ deactivate_offers.short_description = _("Deactivate selected offers")
 
 class ItemOfferInline(CommonOfferInline):
     model = models.ResourceRequest
-    formfield_overrides = {TextField: {"widget": Textarea(attrs={"rows": 3, "cols": 40})}}
+    formfield_overrides = {
+        TextField: {"widget": Textarea(attrs={"rows": 3, "cols": 40})}
+    }
+
+    def has_change_permission(self, request, obj):
+        if request.user.is_dsu_user():
+            return False
+        return super().has_change_permission(request, obj)
+
+    def has_add_permission(self, request, obj):
+        if request.user.is_dsu_user():
+            return False
+        return super().has_add_permission(request, obj)
+
+    def has_delete_permission(self, request, obj):
+        if request.user.is_dsu_user():
+            return False
+        return super().has_delete_permission(request, obj)
 
 
 class ItemRequestInline(CommonRequestInline):
     model = models.ResourceRequest
-    formfield_overrides = {TextField: {"widget": Textarea(attrs={"rows": 3, "cols": 40})}}
+    formfield_overrides = {
+        TextField: {"widget": Textarea(attrs={"rows": 3, "cols": 40})}
+    }
+
+    def has_change_permission(self, request, obj):
+        if request.user.is_dsu_user():
+            return False
+        return super().has_change_permission(request, obj)
+
+    def has_add_permission(self, request, obj):
+        if request.user.is_dsu_user():
+            return False
+        return super().has_add_permission(request, obj)
+
+    def has_delete_permission(self, request, obj):
+        if request.user.is_dsu_user():
+            return False
+        return super().has_delete_permission(request, obj)
 
 
 @admin.register(models.Category)
@@ -52,6 +86,7 @@ class AdminTextileCategory(admin.ModelAdmin):
 
 @admin.register(models.ItemOffer)
 class AdminItemOffer(admin.ModelAdmin):
+
     list_display = [
         "id",
         "category",
@@ -63,7 +98,7 @@ class AdminItemOffer(admin.ModelAdmin):
         "town",
         "status",
     ]
-    list_display_links = ["name"]
+    list_display_links = ["category", "name", "status"]
     search_fields = ["name"]
     list_filter = [
         "county_coverage",
@@ -74,6 +109,12 @@ class AdminItemOffer(admin.ModelAdmin):
         "status",
     ]
     readonly_fields = ["added_on", "stock"]
+
+    def get_readonly_fields(self, request, obj=None):
+        if request.user.is_dsu_user():
+            return [f.name for f in self.model._meta.get_fields() if f.name != "status"]
+        return self.readonly_fields
+
     actions = [deactivate_offers]
 
     inlines = (ItemOfferInline,)
@@ -118,6 +159,15 @@ class AdminItemOffer(admin.ModelAdmin):
             },
         ),
         (
+            _("Offer status"),
+            {
+                "fields": (
+                    "status",
+                    "added_on",
+                ),
+            },
+        ),
+        (
             _("Where it is needed"),
             {
                 "fields": (
@@ -134,13 +184,19 @@ class AdminItemOffer(admin.ModelAdmin):
         if not self.has_view_or_change_permission(request):
             queryset = queryset.none()
 
-        if request.user.is_superuser or request.user.groups.filter(name=DSU_GROUP).exists():
+        if request.user.is_superuser or request.user.is_dsu_user():
             return queryset
 
-        if request.user.groups.filter(name=USERS_GROUP).exists():
+        if request.user.is_regular_user():
             return queryset.filter(donor=request.user)
 
         return queryset
+
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if request.user.is_regular_user():
+            if db_field.name == "donor":
+                kwargs["queryset"] = CustomUser.objects.filter(pk=request.user.id)
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
 
 @admin.register(models.ItemRequest)
@@ -158,6 +214,11 @@ class AdminItemRequest(admin.ModelAdmin):
     list_display_links = ["category"]
     search_fields = ["name"]
     readonly_fields = ["added_on", "stock"]
+
+    def get_readonly_fields(self, request, obj=None):
+        if request.user.is_dsu_user():
+            return [f.name for f in self.model._meta.get_fields() if f.name != "status"]
+        return self.readonly_fields
 
     list_filter = [
         "county_coverage",
@@ -206,6 +267,15 @@ class AdminItemRequest(admin.ModelAdmin):
             },
         ),
         (
+            _("Request status"),
+            {
+                "fields": (
+                    "status",
+                    "added_on",
+                ),
+            },
+        ),
+        (
             _("Where it is needed"),
             {
                 "fields": (
@@ -222,10 +292,16 @@ class AdminItemRequest(admin.ModelAdmin):
         if not self.has_view_or_change_permission(request):
             queryset = queryset.none()
 
-        if request.user.is_superuser or request.user.groups.filter(name=DSU_GROUP).exists():
+        if request.user.is_superuser or request.user.is_dsu_user():
             return queryset
 
-        if request.user.groups.filter(name=USERS_GROUP).exists():
+        if request.user.is_regular_user():
             return queryset.filter(made_by=request.user)
 
         return queryset
+
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if request.user.is_regular_user():
+            if db_field.name == "made_by":
+                kwargs["queryset"] = CustomUser.objects.filter(pk=request.user.id)
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)

--- a/revm/app_other/admin.py
+++ b/revm/app_other/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.utils.translation import gettext_lazy as _
 
-from app_account.models import USERS_GROUP, DSU_GROUP
+from app_account.models import CustomUser
 from app_other import models
 from revm_site.admin import CommonRequestInline, CommonOfferInline
 from revm_site.utils import CountyFilter
@@ -10,9 +10,39 @@ from revm_site.utils import CountyFilter
 class OtherOfferInline(CommonOfferInline):
     model = models.ResourceRequest
 
+    def has_change_permission(self, request, obj):
+        if request.user.is_dsu_user():
+            return False
+        return super().has_change_permission(request, obj)
+
+    def has_add_permission(self, request, obj):
+        if request.user.is_dsu_user():
+            return False
+        return super().has_add_permission(request, obj)
+
+    def has_delete_permission(self, request, obj):
+        if request.user.is_dsu_user():
+            return False
+        return super().has_delete_permission(request, obj)
+
 
 class OtherRequestInline(CommonRequestInline):
     model = models.ResourceRequest
+
+    def has_change_permission(self, request, obj):
+        if request.user.is_dsu_user():
+            return False
+        return super().has_change_permission(request, obj)
+
+    def has_add_permission(self, request, obj):
+        if request.user.is_dsu_user():
+            return False
+        return super().has_add_permission(request, obj)
+
+    def has_delete_permission(self, request, obj):
+        if request.user.is_dsu_user():
+            return False
+        return super().has_delete_permission(request, obj)
 
 
 @admin.register(models.Category)
@@ -28,10 +58,24 @@ class AdminCategoryRequest(admin.ModelAdmin):
 
 @admin.register(models.OtherOffer)
 class AdminOtherOffer(admin.ModelAdmin):
-    list_display = ("id", "category", "name", "available_until", "county_coverage", "town", "status")
+    list_display = (
+        "id",
+        "category",
+        "name",
+        "available_until",
+        "county_coverage",
+        "town",
+        "status",
+    )
     list_display_links = ("id", "name")
     search_fields = ["name"]
     readonly_fields = ["added_on"]
+
+    def get_readonly_fields(self, request, obj=None):
+        if request.user.is_dsu_user():
+            return [f.name for f in self.model._meta.get_fields() if f.name != "status"]
+        return self.readonly_fields
+
     list_filter = ("category", "status", CountyFilter)
     inlines = (OtherOfferInline,)
 
@@ -63,13 +107,19 @@ class AdminOtherOffer(admin.ModelAdmin):
         if not self.has_view_or_change_permission(request):
             queryset = queryset.none()
 
-        if request.user.is_superuser or request.user.groups.filter(name=DSU_GROUP).exists():
+        if request.user.is_superuser or request.user.is_dsu_user():
             return queryset
 
-        if request.user.groups.filter(name=USERS_GROUP).exists():
+        if request.user.is_regular_user():
             return queryset.filter(donor=request.user)
 
         return queryset
+
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if request.user.is_regular_user():
+            if db_field.name == "donor":
+                kwargs["queryset"] = CustomUser.objects.filter(pk=request.user.id)
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
 
 @admin.register(models.OtherRequest)
@@ -78,6 +128,12 @@ class AdminOtherRequest(admin.ModelAdmin):
     list_display_links = ("id", "name")
     search_fields = ["name"]
     readonly_fields = ["added_on"]
+
+    def get_readonly_fields(self, request, obj=None):
+        if request.user.is_dsu_user():
+            return [f.name for f in self.model._meta.get_fields() if f.name != "status"]
+        return self.readonly_fields
+
     list_filter = ("category", "status", CountyFilter)
 
     inlines = (OtherRequestInline,)
@@ -109,10 +165,19 @@ class AdminOtherRequest(admin.ModelAdmin):
         if not self.has_view_or_change_permission(request):
             queryset = queryset.none()
 
-        if request.user.is_superuser or request.user.groups.filter(name=DSU_GROUP).exists():
+        if (
+            request.user.is_superuser
+            or request.user.is_dsu_user()
+        ):
             return queryset
 
-        if request.user.groups.filter(name=USERS_GROUP).exists():
+        if request.user.is_regular_user():
             return queryset.filter(made_by=request.user)
 
         return queryset
+
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if request.user.is_regular_user():
+            if db_field.name == "made_by":
+                kwargs["queryset"] = CustomUser.objects.filter(pk=request.user.id)
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)

--- a/revm/app_volunteering/admin.py
+++ b/revm/app_volunteering/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.utils.translation import gettext_lazy as _
 
-from app_account.models import USERS_GROUP, DSU_GROUP
+from app_account.models import CustomUser
 from app_volunteering import models
 from revm_site.admin import CommonRequestInline, CommonOfferInline
 from revm_site.utils import CountyFilter
@@ -10,10 +10,38 @@ from revm_site.utils import CountyFilter
 class VolunteeringOfferInline(CommonOfferInline):
     model = models.ResourceRequest
 
+    def has_change_permission(self, request, obj):
+        if request.user.is_dsu_user():
+            return False
+        return super().has_change_permission(request, obj)
+
+    def has_add_permission(self, request, obj):
+        if request.user.is_dsu_user():
+            return False
+        return super().has_add_permission(request, obj)
+
+    def has_delete_permission(self, request, obj):
+        if request.user.is_dsu_user():
+            return False
+        return super().has_delete_permission(request, obj)
 
 class VolunteeringRequestInline(CommonRequestInline):
     model = models.ResourceRequest
 
+    def has_change_permission(self, request, obj):
+        if request.user.is_dsu_user():
+            return False
+        return super().has_change_permission(request, obj)
+
+    def has_add_permission(self, request, obj):
+        if request.user.is_dsu_user():
+            return False
+        return super().has_add_permission(request, obj)
+
+    def has_delete_permission(self, request, obj):
+        if request.user.is_dsu_user():
+            return False
+        return super().has_delete_permission(request, obj)
 
 @admin.register(models.Type)
 class AdminTypeRequest(admin.ModelAdmin):
@@ -33,6 +61,12 @@ class AdminVolunteeringOffer(admin.ModelAdmin):
     list_filter = ["type", CountyFilter, "status"]
     search_fields = ["name"]
     readonly_fields = ["added_on"]
+
+    def get_readonly_fields(self, request, obj=None):
+        if request.user.is_dsu_user():
+            return [f.name for f in self.model._meta.get_fields() if f.name != "status"]
+        return self.readonly_fields
+
     inlines = (VolunteeringOfferInline,)
 
     ordering = ("pk",)
@@ -62,13 +96,19 @@ class AdminVolunteeringOffer(admin.ModelAdmin):
         if not self.has_view_or_change_permission(request):
             queryset = queryset.none()
 
-        if request.user.is_superuser or request.user.groups.filter(name=DSU_GROUP).exists():
+        if request.user.is_superuser or request.user.is_dsu_user():
             return queryset
 
-        if request.user.groups.filter(name=USERS_GROUP).exists():
+        if request.user.is_regular_user():
             return queryset.filter(donor=request.user)
 
         return queryset
+
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if request.user.is_regular_user():
+            if db_field.name == "donor":
+                kwargs["queryset"] = CustomUser.objects.filter(pk=request.user.id)
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
 
 @admin.register(models.VolunteeringRequest)
@@ -78,6 +118,12 @@ class AdminVolunteeringRequest(admin.ModelAdmin):
     list_filter = ["type", CountyFilter, "status"]
     search_fields = ["name"]
     readonly_fields = ["added_on"]
+
+    def get_readonly_fields(self, request, obj=None):
+        if request.user.is_dsu_user():
+            return [f.name for f in self.model._meta.get_fields() if f.name != "status"]
+        return self.readonly_fields
+
     inlines = (VolunteeringRequestInline,)
 
     ordering = ("pk",)
@@ -106,10 +152,10 @@ class AdminVolunteeringRequest(admin.ModelAdmin):
         if not self.has_view_or_change_permission(request):
             queryset = queryset.none()
 
-        if request.user.is_superuser or request.user.groups.filter(name=DSU_GROUP).exists():
+        if request.user.is_superuser or request.user.is_dsu_user():
             return queryset
 
-        if request.user.groups.filter(name=USERS_GROUP).exists():
+        if request.user.is_regular_user():
             return queryset.filter(made_by=request.user)
 
         return queryset


### PR DESCRIPTION
<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?
<!--
If it is related to an open issue, please link the issue here. 
-->
### Add special permissions:

>Group `USERS`:
* when creating/adding offer, donor choice to be restricted to current user

>Group `DSU`:
* can only change verification status - no other fields

Additionally, extended `CustomUser` API with following methods:

* `is_regular_user`
* `is_dsu_user`
* `is_dsu_manager_user`
* `user_type`

Added User Type in User `list_view`

Closes #78 

<!-- Please mention the main changes this PR brings. -->

### How has it been tested?

<!-- Please describe the tests that you ran to verify your changes. -->
Checked each resource (offer & request) for each user type so that it behaves as expected.
<!-- If applicable, mention any known issues with the pull request -->
